### PR TITLE
CB-7098 Fix reference to CordovaAppHarness.java

### DIFF
--- a/createproject.sh
+++ b/createproject.sh
@@ -94,7 +94,7 @@ set +x
 
 if [[ "$PLATFORMS" = *android* ]]; then
     echo 'var fs = require("fs");
-          var fname = "platforms/android/src/org/chromium/appdevtool/ChromeAppDeveloperTool.java";
+          var fname = "platforms/android/src/org/apache/appharness/CordovaAppHarness.java";
           var tname = "'$AH_PATH'/template-overrides/Activity.java";
           var orig = fs.readFileSync(fname, "utf8");
           var templ = fs.readFileSync(tname, "utf8");


### PR DESCRIPTION
createproject.sh failed due to the missing ChromeAppDeveloperTool.java,
updated reference to CordovaAppHarness.java
