### PR TITLE
Updated License with a Valid SPDX License

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/apache/cordova-app-harness.git"
   },
   "author": "The Cordova Team",
-  "license": "Apache version 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "http://issues.apache.org/jira/browse/CB"
   },


### PR DESCRIPTION
### Platforms affected
none

### What does this PR do?
Fixes the NPM's invalid license warning message. The `package.json` contains an invalid SPDX license expression.

**Warning Message**
```
npm WARN ... license should be a valid SPDX license expression
```
**Changes**
`"license": "Apache Version 2.0",` becomes `"license": "Apache-2.0",`

### What testing has been done on this change?
- `npm i`